### PR TITLE
Fix scrollbar behavior by replacing overflow: scroll with overflow: auto

### DIFF
--- a/frontend/src/Components/Scroller/Scroller.css
+++ b/frontend/src/Components/Scroller/Scroller.css
@@ -12,7 +12,7 @@
 
 .vertical {
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   &.autoScroll {
     overflow-y: auto;
@@ -20,7 +20,7 @@
 }
 
 .horizontal {
-  overflow-x: scroll;
+  overflow-x: auto;
   overflow-y: hidden;
 
   &.autoScroll {
@@ -29,7 +29,7 @@
 }
 
 .both {
-  overflow: scroll;
+  overflow: auto;
 
   &.autoScroll {
     overflow: auto;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Replaces `overflow: scroll` with `overflow: auto` in the Scroller component.

Using `overflow: scroll` forces scrollbars to appear even when the content does not overflow the container.  
Changing it to `overflow: auto` ensures scrollbars only appear when necessary, improving UI behavior without affecting scrolling functionality.

#### Screenshot (if UI related)
N/A

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

* Fixes #45