### PR TITLE
fix(ui): reduce discovery page movie title font size

### DIFF
--- a/frontend/src/DiscoverMovie/Posters/DiscoverMoviePoster.css
+++ b/frontend/src/DiscoverMovie/Posters/DiscoverMoviePoster.css
@@ -44,7 +44,7 @@ $hoverScale: 1.05;
   height: 100%;
   color: var(--offWhite);
   text-align: center;
-  font-size: 20px;
+  font-size: $smallFontSize;
 }
 
 .title {


### PR DESCRIPTION
## Description
Fixes the issue where movie titles on the discovery page are displayed too large.

## Changes
- Changed overlayTitle font-size from 20px to $smallFontSize
- Ensures consistency with other page elements
- Improves readability and layout on discovery page

## Testing
- Verified font size matches other UI elements
- Checked that long titles still display correctly

Fixes #46