### PR TITLE
[RADARR] v1.0.0 — Replace blocked coverage report action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1057,13 +1057,15 @@ jobs:
         shell: pwsh
 
       - name: Generate coverage report
-        uses: danielpalme/ReportGenerator-GitHub-Action@5
         if: always()
-        with:
-          reports: CoverageResults/**/coverage.cobertura.xml
-          targetdir: CoverageResults/combined
-          reporttypes: HtmlInline;Cobertura;Badges
-          sourcedirs: src
+        run: |
+          dotnet tool install --tool-path ./.tools dotnet-reportgenerator-globaltool --version 5.*
+          ./.tools/reportgenerator `
+            "-reports:CoverageResults/**/coverage.cobertura.xml" `
+            "-targetdir:CoverageResults/combined" `
+            "-reporttypes:HtmlInline;Cobertura;Badges" `
+            "-sourcedirs:src"
+        shell: pwsh
 
   # ---------------------------------------------------------------------------
   # API Docs: generate OpenAPI spec, create PR


### PR DESCRIPTION
## Summary
- replace the blocked `danielpalme/ReportGenerator-GitHub-Action@5` step in `.github/workflows/ci.yml`
- generate the coverage report with the `dotnet-reportgenerator-globaltool` instead
- keep the existing coverage output paths and report types unchanged

## Root Cause
The last two `CI` workflow runs failed at startup before creating any jobs because the workflow referenced a GitHub Action blocked by the organization's action policy.

## Validation
- `git diff --check`
- `actionlint .github/workflows/ci.yml`

## Remaining Risk
- live GitHub Actions execution is still unverified until this branch runs in Actions
